### PR TITLE
Fix: Replace deprecated async_forward_entry_setup

### DIFF
--- a/custom_components/speedport/__init__.py
+++ b/custom_components/speedport/__init__.py
@@ -37,10 +37,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     entry.async_on_unload(entry.add_update_listener(update_listener))
 
-    for platform in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
-        )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
     return True
 
 
@@ -57,3 +55,4 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await speedport.close()
 
     return unload_ok
+


### PR DESCRIPTION
Updated __init__.py for compatibility with Home Assistant 2024.6+

Adapt from https://github.com/Andre0512/speedport/pull/33