### PR TITLE
Change category from "plugin" to "integration" in "Open HACS repository" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The Speedport is not available in [HACS][hacs] (Home Assistant Community Store) 
 2. Open HACS in Home Assistant 
 3. Add this repository (https://github.com/MelleD/speedport) via HACS Custom repositories ([How to add Custom Repositories](https://hacs.xyz/docs/faq/custom_repositories/))
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=MelleD&repository=speedport&category=plugin)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=MelleD&repository=speedport&category=integration)
 
 ### Manuall (not recommended)
 


### PR DESCRIPTION
The category was set to `plugin` which causes the files to be installed to `/config/www/community/seedport` instead of `/config/custom_components/speedport`. This caused the integration to never appear in the `Add Integration` list.

>Note: If this was an intentional change in https://github.com/MelleD/speedport/commit/b086a977e658443fc308645a047283df477cbc78 feel free to reject but with the repository category set to `plugin` I was unable to add this integration. Trying after clearing cache or using a private window didn't show the integration in the list :shrug: